### PR TITLE
Quick bugfix for crash on erasing from std::deque

### DIFF
--- a/src/drawable.cpp
+++ b/src/drawable.cpp
@@ -100,16 +100,18 @@ void Drawable::subRemove(Drawable *t) {
 }
 
 void Drawable::subRemoveFinished() {
-	for (auto it = m_subs.begin(); it != m_subs.end(); it++) {
+	for (auto it = m_subs.begin(); it != m_subs.end();) {
 		if (!(*it)->isFinished()) {
 			(*it)->m_parent = nullptr;
 			it = m_subs.erase(it);
+		} else {
+			it++;
 		}
 	}
 }
 
 void Drawable::subRemoveAll() {
-	for (auto it = m_subs.begin(); it != m_subs.end(); it++) {
+	for (auto it = m_subs.begin(); it != m_subs.end();) {
 		(*it)->m_parent = nullptr;
 		it = m_subs.erase(it);
 	}


### PR DESCRIPTION
- When erasing iterators while iterating over containers, you don't want to increment the iterator returned from erase(), since it is already the next element